### PR TITLE
Added new parameter: convert_timestamp

### DIFF
--- a/bin/elasticsplunk.py
+++ b/bin/elasticsplunk.py
@@ -10,6 +10,7 @@ import sys
 import json
 import time
 import calendar
+import dateparser
 from datetime import datetime
 from pprint import pprint
 from elasticsearch import Elasticsearch, helpers
@@ -118,9 +119,9 @@ class ElasticSplunk(GeneratingCommand):
     @staticmethod
     def to_epoch(timestring):
         """Convert UTC date string returned by elasticsearch to epoch"""
-        dt = datetime.strptime(timestring, "%Y-%m-%dT%H:%M:%S.%fZ")
-        return str(calendar.timegm(dt.timetuple())) + "." + str(dt.microsecond)
-
+        dt = dateparser.parse(timestring)
+       	utc_dt = dt.replace(tzInfo=None) - dt.utcoffset()
+	return (utc_dt - datetime(1970, 1, 1)).total_seconds()
 
     def _get_search_config(self):
         """Parse and configure search parameters"""

--- a/default/searchbnf.conf
+++ b/default/searchbnf.conf
@@ -13,6 +13,6 @@ tags = search elasticsearch
 related = search
 
 [ess-options]
-syntax = eaddr=<string> | action=<string> | scan=<bool> | index=<string> | stype=<string> | tsfield=<string> | query=<string> | fields=<string> | limit=<int> | include_es=<bool> | include_raw=<bool>| earliest=<string> | earliest=<string> | latest=<latest>
+syntax = eaddr=<string> | action=<string> | scan=<bool> | index=<string> | stype=<string> | tsfield=<string> | query=<string> | fields=<string> | limit=<int> | include_es=<bool> | include_raw=<bool>| earliest=<string> | earliest=<string> | latest=<latest> | convert_timestamp=<bool>
 description = Search ElasticSearch within Splunk
 


### PR DESCRIPTION
When elasticsearch returns timestamp fields, like
`@timestamp` from filebeats/logstash etc, they are returned as
strings formatted like **'2018-08-28T06:55:23.471Z'** (UTC time)
These strings are displayed OK by elasticsearch, but can't be
used by splunk commands like `timechart`, which need the timestamp to
be in unix epoch time format.

This optional parameter converts the timestamp to this format.

Uses `calendar.timegm()`, since that expects the time as UTC, while
`time.mktime()` expects local time. Concatenate with microseconds part
when returning to not loose precision as `calendar.timegm()` returns a integer

<img width="978" alt="screen shot 2018-09-10 at 20 19 42" src="https://user-images.githubusercontent.com/7224004/45316935-d1f39e00-b538-11e8-9ee2-684dbe57ddf7.png">

<img width="967" alt="screen shot 2018-09-10 at 20 20 17" src="https://user-images.githubusercontent.com/7224004/45316941-d8821580-b538-11e8-866c-8bd55facb605.png">

